### PR TITLE
bruteforce-crc.cc: Fix errors with `initial` & example implementation

### DIFF
--- a/bf_crc.cc
+++ b/bf_crc.cc
@@ -110,9 +110,19 @@ std::string bitset_to_byte_array(boost::dynamic_bitset<> const & message) {
   std::string ret;
 
   uint8_t byte = 0;
+  
+  // for the first byte
+  for(size_t j = 0; j < 8; j++) {
+    byte <<= 1;
+    byte |= (message[j] == true ? 1 : 0); 
+  }
 
+  boost::format f("0x%02x");
+  f % static_cast<int>(byte);
+  ret.append(f.str());
 
-  for(size_t i = 0; i < message.size(); i+=8) {
+  // for all subsequent bytes
+  for(size_t i = 8; i < message.size(); i+=8) {
 
     byte = 0;
 
@@ -121,16 +131,11 @@ std::string bitset_to_byte_array(boost::dynamic_bitset<> const & message) {
       byte |= (message[i + j] == true ? 1 : 0);
     }
 
-    boost::format f("0x%02x, ");
+    boost::format f(", 0x%02x");
     f % static_cast<int>(byte);
     ret.append(f.str());
 
   }
-
-  boost::format f("0x%02x");
-  f % static_cast<int>(byte);
-
-  ret.append(f.str());
 
   return ret;
 }

--- a/bruteforce-crc.cc
+++ b/bruteforce-crc.cc
@@ -146,7 +146,7 @@ int main(int argc, char *argv[]) {
 	bool reflected_output = false;
 
 	uint32_t initial = 0;
-	bool probe_initial = true;
+	bool probe_initial = false;
 
 	uint32_t final_xor = 0;
 	bool probe_final_xor = false;
@@ -174,7 +174,7 @@ int main(int argc, char *argv[]) {
 	  ("poly-end",				po::value<uint32_t>(),			"End of polynomial search space (default (2^width - 1))")
 	  
 	  ("threads", 				po::value<unsigned int >(), 	"Number of threads (default: 4)")
-	  ("initial", 				po::value<size_t>(), 			"Set intial value (default: 0)")
+	  ("initial", 				po::value<uint32_t>(), 			"Set intial value (default: 0)")
 
 	  ("probe-initial", 			po::value<bool>(), 				"Bruteforce the intial, overrides initial (default: true)")
 	  ("final-xor", 				po::value<uint32_t>(), 			"Final xor (default: 0)")


### PR DESCRIPTION
Fixes #4. Fixes #5.

1. Since `initial` was declared to be `uint32_t`, the conversion of the
argument should likewise be converted to `uint32_t`. `size_t` converts
it to 8-bytes, which will not fit into 4-bytes.

2. `probe_initial` should be set to false by default to prevent the
current bug. The current bug causes the program to ignore the user
specified value `--initial x` and bruteforce crc seeds.

3. The extra byte output is a typical fence post problem. Fixed with
this PR.

Signed-off-by: Solomon Tan <solomonbstoner@yahoo.com.au>